### PR TITLE
Enhance the AD display on the permission page & hide the result window after sharing the text

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/result/ResultView.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/result/ResultView.kt
@@ -123,7 +123,7 @@ class ResultView(context: Context) : FloatingView(context) {
         btShareOCRText.clickOnce {
             val ocrText = viewModel.ocrText.value ?: return@clickOnce
             Utils.shareText(ocrText)
-            viewResultWindow.visibility = View.GONE
+            onUserDismiss?.invoke()
         }
     }
 

--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/result/ResultView.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/result/ResultView.kt
@@ -123,6 +123,7 @@ class ResultView(context: Context) : FloatingView(context) {
         btShareOCRText.clickOnce {
             val ocrText = viewModel.ocrText.value ?: return@clickOnce
             Utils.shareText(ocrText)
+            viewResultWindow.visibility = View.GONE
         }
     }
 

--- a/main/src/main/res/layout/activity_launch.xml
+++ b/main/src/main/res/layout/activity_launch.xml
@@ -25,12 +25,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/line_ads"
+    <!--<androidx.constraintlayout.widget.Barrier
+       android:id="@+id/line_ads"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="admobAd" />
+        app:constraint_referenced_ids="admobAd" /> />-->
 
     <fragment
         android:id="@+id/nav_host_fragment"
@@ -42,7 +42,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/admobAd"
+        app:layout_constraintTop_toTopOf="parent"
         app:navGraph="@navigation/launch_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/main/src/main/res/layout/activity_launch.xml
+++ b/main/src/main/res/layout/activity_launch.xml
@@ -42,7 +42,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/line_ads"
+        app:layout_constraintTop_toTopOf="@+id/admobAd"
         app:navGraph="@navigation/launch_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
keep (Request permission) button in the middle of screen instead of go down after the AD show

hide Result Window after clicking share button so it won't be in front of share page