### PR TITLE
The quick tile state is not correct after device rebooted

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/manager/FloatingStateManager.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/manager/FloatingStateManager.kt
@@ -4,10 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Rect
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import tw.firemaples.onscreenocr.R
 import tw.firemaples.onscreenocr.floatings.base.FloatingView
@@ -57,10 +54,8 @@ object FloatingStateManager {
         }
     }
 
-    private val _showingStateChangedFlow = MutableSharedFlow<Boolean>(
-        replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    val showingStateChangedFlow: SharedFlow<Boolean> = _showingStateChangedFlow
+    private val _showingStateChangedFlow = MutableStateFlow(false)
+    val showingStateChangedFlow: StateFlow<Boolean> = _showingStateChangedFlow
     val isMainBarAttached: Boolean
         get() = mainBar.attached
 

--- a/main/src/main/java/tw/firemaples/onscreenocr/utils/QuickTileService.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/utils/QuickTileService.kt
@@ -7,7 +7,6 @@ import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.collect
 import tw.firemaples.onscreenocr.floatings.manager.FloatingStateManager
 import tw.firemaples.onscreenocr.pages.launch.LaunchActivity
 import tw.firemaples.onscreenocr.screenshot.ScreenExtractor
@@ -71,6 +70,7 @@ class QuickTileService : TileService() {
     }
 
     private fun updateTileState(isShowing: Boolean) {
+        logger.debug("updateTileState, isShowing: $isShowing")
         val tile = qsTile ?: return
         tile.state = if (isShowing) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
         tile.updateTile()


### PR DESCRIPTION
The default state of quick tile items is active on Android 9