### PR TITLE
Skip whole-black screenshots

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/utils/Constants.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/utils/Constants.kt
@@ -12,6 +12,7 @@ object Constants {
 
     const val PATH_SCREENSHOT: String = "screenshot"
     const val TIMEOUT_EXTRACT_SCREEN = 5
+    const val EXTRACT_SCREEN_MAX_RETRY = 10
 
     const val MIN_SCREEN_CROP_SIZE = 32
 


### PR DESCRIPTION
Skip whole-black screenshots and wait for the next frame.

Fix #289 