### PR TITLE
Keep MediaProjection resources

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/launch/LaunchActivity.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/launch/LaunchActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import tw.firemaples.onscreenocr.databinding.ActivityLaunchBinding
 import tw.firemaples.onscreenocr.remoteconfig.RemoteConfigManager
 import tw.firemaples.onscreenocr.utils.AdManager
+import tw.firemaples.onscreenocr.utils.DeviceInfoChecker
 
 class LaunchActivity : AppCompatActivity() {
 
@@ -29,5 +30,7 @@ class LaunchActivity : AppCompatActivity() {
 //        MoPubAdManager.loadPermissionPageBanner(this, findViewById(R.id.ad_permissionPage))
 
         RemoteConfigManager.tryFetchNew()
+
+        DeviceInfoChecker.check()
     }
 }

--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/launch/permissions/PermissionCaptureScreenFragment.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/launch/permissions/PermissionCaptureScreenFragment.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import tw.firemaples.onscreenocr.databinding.PermissionCaptureScreenFragmentBinding
 import tw.firemaples.onscreenocr.floatings.ViewHolderService
+import tw.firemaples.onscreenocr.pages.setting.SettingManager
 import tw.firemaples.onscreenocr.screenshot.ScreenExtractor
 import tw.firemaples.onscreenocr.utils.clickOnce
 
@@ -54,7 +55,10 @@ class PermissionCaptureScreenFragment : Fragment() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             val intent = it.data
             if (it.resultCode == Activity.RESULT_OK && intent != null) {
-                ScreenExtractor.onMediaProjectionGranted(intent, true)
+                ScreenExtractor.onMediaProjectionGranted(
+                    intent = intent,
+                    keepMediaProjection = SettingManager.keepMediaProjectionResources,
+                )
                 startService()
             }
         }

--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/launch/permissions/PermissionCaptureScreenFragment.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/launch/permissions/PermissionCaptureScreenFragment.kt
@@ -54,7 +54,7 @@ class PermissionCaptureScreenFragment : Fragment() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             val intent = it.data
             if (it.resultCode == Activity.RESULT_OK && intent != null) {
-                ScreenExtractor.onMediaProjectionGranted(intent)
+                ScreenExtractor.onMediaProjectionGranted(intent, true)
                 startService()
             }
         }

--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingFragment.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingFragment.kt
@@ -8,7 +8,9 @@ import android.text.InputType
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import tw.firemaples.onscreenocr.R
+import tw.firemaples.onscreenocr.utils.Toaster
 import tw.firemaples.onscreenocr.utils.Utils
 
 class SettingFragment : PreferenceFragmentCompat() {
@@ -17,7 +19,10 @@ class SettingFragment : PreferenceFragmentCompat() {
         get() = findPreference("pref_bypass_battery_optimization")
 
     private val myMemoryEmail: EditTextPreference?
-        get() = findPreference("pref_mymemory_email")
+        get() = findPreference(SettingManager.PREF_MYMEMORY_EMAIL)
+
+    private val keepMediaProjectionResources: SwitchPreference?
+        get() = findPreference(SettingManager.PREF_KEEP_MEDIA_PROJECTION_RESOURCES)
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.perference, rootKey)
@@ -31,6 +36,11 @@ class SettingFragment : PreferenceFragmentCompat() {
 
         myMemoryEmail?.setOnBindEditTextListener {
             it.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+        }
+
+        keepMediaProjectionResources?.setOnPreferenceChangeListener { _, _ ->
+            Toaster.show(getString(R.string.msg_please_restart_the_app_to_take_effect))
+            true
         }
     }
 

--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingManager.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingManager.kt
@@ -1,6 +1,7 @@
 package tw.firemaples.onscreenocr.pages.setting
 
 import android.content.Context
+import androidx.core.content.edit
 import androidx.core.util.PatternsCompat
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.CoroutineScope
@@ -60,8 +61,11 @@ object SettingManager {
     val opaquePercentageToFadeOut: Float
         get() = preferences.getInt(PREF_OPAQUE_PERCENTAGE, 60).toFloat() / 100f
 
-    val keepMediaProjectionResources: Boolean
+    var keepMediaProjectionResources: Boolean
         get() = preferences.getBoolean(PREF_KEEP_MEDIA_PROJECTION_RESOURCES, false)
+        set(value) {
+            preferences.edit { putBoolean(PREF_KEEP_MEDIA_PROJECTION_RESOURCES, value) }
+        }
 
     val enableUnrecommendedLangItems: Boolean
         get() = preferences.getBoolean(PREF_ENABLE_UNRECOMMENDED_LANG_ITEMS, false)

--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingManager.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingManager.kt
@@ -20,6 +20,8 @@ object SettingManager {
     private const val PREF_FADE_OUT_AFTER_SECONDS = "pref_fade_out_after_seconds"
     private const val PREF_OPAQUE_PERCENTAGE = "pref_opaque_percentage"
 
+    const val PREF_KEEP_MEDIA_PROJECTION_RESOURCES = "pref_keep_media_projection_resources"
+
     private const val PREF_ENABLE_UNRECOMMENDED_LANG_ITEMS = "pref_enable_unrecommended_lang_items"
     private const val PREF_TIMEOUT_FOR_CAPTURING_SCREEN = "pref_timeout_for_capturing_screen"
     private const val PREF_TEXT_BLOCK_JOINER = "pref_text_block_joiner"
@@ -34,7 +36,7 @@ object SettingManager {
     private const val PREF_SAVE_LAST_SELECTION_AREA = "pref_save_last_selection_area"
     private const val PREF_EXIT_APP_WHILE_SPEN_INSERTED = "pref_exit_app_while_spen_inserted"
 
-    private const val PREF_MYMEMORY_EMAIL = "pref_mymemory_email"
+    const val PREF_MYMEMORY_EMAIL = "pref_mymemory_email"
 
     private val DEFAULT_JOINER = TextBlockJoiner.Space
 
@@ -57,6 +59,9 @@ object SettingManager {
 
     val opaquePercentageToFadeOut: Float
         get() = preferences.getInt(PREF_OPAQUE_PERCENTAGE, 60).toFloat() / 100f
+
+    val keepMediaProjectionResources: Boolean
+        get() = preferences.getBoolean(PREF_KEEP_MEDIA_PROJECTION_RESOURCES, false)
 
     val enableUnrecommendedLangItems: Boolean
         get() = preferences.getBoolean(PREF_ENABLE_UNRECOMMENDED_LANG_ITEMS, false)

--- a/main/src/main/java/tw/firemaples/onscreenocr/pref/AppPref.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pref/AppPref.kt
@@ -52,4 +52,6 @@ object AppPref : KotprefModel() {
     val favoriteTranslationLang: MutableSet<String> by stringSetPref(default = mutableSetOf("en"))
 
     var displaySelectedTextOnResultWindow: Boolean by booleanPref(default = false)
+
+    var lastDeviceInfo: String by stringPref()
 }

--- a/main/src/main/java/tw/firemaples/onscreenocr/utils/DeviceInfoChecker.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/utils/DeviceInfoChecker.kt
@@ -1,0 +1,42 @@
+package tw.firemaples.onscreenocr.utils
+
+import android.os.Build
+import tw.firemaples.onscreenocr.pages.setting.SettingManager
+import tw.firemaples.onscreenocr.pref.AppPref
+
+object DeviceInfoChecker {
+    private val logger: Logger by lazy { Logger(this::class) }
+    fun check() {
+        val manufacturer = Build.MANUFACTURER
+        val model = Build.MODEL
+        val os = Build.VERSION.SDK_INT
+
+        val deviceInfo = "$manufacturer,$model,$os"
+        logger.debug("DeviceInfo: $deviceInfo")
+
+        if (deviceInfo != AppPref.lastDeviceInfo) {
+            when {
+                manufacturer.contains("Xiaomi", ignoreCase = true) &&
+                        os >= Build.VERSION_CODES.S -> {
+                    keepMediaProjectionResources()
+                }
+
+                manufacturer.contains("Blackshark", ignoreCase = true) &&
+                        os >= Build.VERSION_CODES.S -> {
+                    keepMediaProjectionResources()
+                }
+
+                os >= 34 -> {
+                    keepMediaProjectionResources()
+                }
+            }
+        }
+
+        AppPref.lastDeviceInfo = deviceInfo
+    }
+
+    private fun keepMediaProjectionResources() {
+        logger.debug("keepMediaProjectionResources()")
+        SettingManager.keepMediaProjectionResources = true
+    }
+}

--- a/main/src/main/java/tw/firemaples/onscreenocr/utils/Toaster.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/utils/Toaster.kt
@@ -3,15 +3,19 @@ package tw.firemaples.onscreenocr.utils
 import android.content.Context
 import android.widget.Toast
 import androidx.annotation.StringRes
+import java.lang.ref.WeakReference
 
 object Toaster {
     private val context: Context by lazy { Utils.context }
+    private var last: WeakReference<Toast>? = null
 
     fun show(msg: String) {
-        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+        last?.get()?.cancel()
+        last = WeakReference(Toast.makeText(context, msg, Toast.LENGTH_LONG).apply { show() })
     }
 
     fun show(@StringRes stringRes: Int) {
-        Toast.makeText(context, stringRes, Toast.LENGTH_SHORT).show()
+        last?.get()?.cancel()
+        last = WeakReference(Toast.makeText(context, stringRes, Toast.LENGTH_LONG).apply { show() })
     }
 }

--- a/main/src/main/res/values-zh-rCN/strings.xml
+++ b/main/src/main/res/values-zh-rCN/strings.xml
@@ -107,4 +107,9 @@
     <string name="pref_summary_mymemory_email">提供 MyMemory 翻译你的电子邮件以获取每日五万个字元的翻译额度。随处翻译将不会使用此电子邮件作为其他用途。</string>
     <string name="pref_title_mymemory_email">MyMemory 电子邮件</string>
     <string name="text_open_in_browser">在浏览器中开启</string>
+    <string name="msg_please_restart_the_app_to_take_effect">重启程式以生效</string>
+    <string name="pref_title_keep_media_projection_resources">维持萤幕截图相关资源</string>
+    <string name="pref_summary_on_keep_media_projection_resources">维持相关资源直到重启程式</string>
+    <string name="pref_summary_off_keep_media_projection_resources">每次使用后释放相关资源</string>
+    <string name="pref_screenshot">萤幕截图</string>
 </resources>

--- a/main/src/main/res/values-zh-rTW/strings.xml
+++ b/main/src/main/res/values-zh-rTW/strings.xml
@@ -107,4 +107,9 @@
     <string name="pref_summary_mymemory_email">提供 MyMemory 翻譯你的電子郵件以獲取每日五萬個字元的翻譯額度。隨處翻譯將不會使用此電子郵件作為其他用途。</string>
     <string name="pref_title_mymemory_email">MyMemory 電子郵件</string>
     <string name="text_open_in_browser">在瀏覽器中開啟</string>
+    <string name="msg_please_restart_the_app_to_take_effect">重啟程式以生效</string>
+    <string name="pref_title_keep_media_projection_resources">維持螢幕截圖相關資源</string>
+    <string name="pref_summary_on_keep_media_projection_resources">維持相關資源直到重啟程式</string>
+    <string name="pref_summary_off_keep_media_projection_resources">每次使用後釋放相關資源</string>
+    <string name="pref_screenshot">螢幕截圖</string>
 </resources>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="pref_category_translation">Translation</string>
     <string name="pref_summary_mymemory_email">You can Provide a valid email to MyMemory translation for 50000 chars a day quota.\nEverTranslator will never use the email for other usages.</string>
     <string name="pref_title_mymemory_email">MyMemory email</string>
+    <string name="pref_screenshot">Screenshot</string>
+    <string name="pref_title_keep_media_projection_resources">Keep screenshot resources</string>
+    <string name="pref_summary_on_keep_media_projection_resources">Keep the resources until restart</string>
+    <string name="pref_summary_off_keep_media_projection_resources">Release the resources after used</string>
 
     <string name="menu_setting">Setting</string>
     <string name="menu_privacy_policy">Privacy Policy</string>
@@ -81,6 +85,7 @@
     <string name="msg_create_selection_area">Drag here to create a translation area</string>
     <string name="msg_image_reader_format_unmatched">Found temporary error, please try it again. (Image reader format)</string>
     <string name="msg_translator_provider_does_not_support_the_ocr_lang">This translation provider does not support the selected recognition language.</string>
+    <string name="msg_please_restart_the_app_to_take_effect">Please restart the app to take effect</string>
 
     <string name="title_version_history">Version History</string>
     <string name="title_error">Error</string>

--- a/main/src/main/res/xml/perference.xml
+++ b/main/src/main/res/xml/perference.xml
@@ -34,6 +34,15 @@
             app:showSeekBarValue="true" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/pref_screenshot">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="pref_keep_media_projection_resources"
+            android:summaryOff="@string/pref_summary_off_keep_media_projection_resources"
+            android:summaryOn="@string/pref_summary_on_keep_media_projection_resources"
+            android:title="@string/pref_title_keep_media_projection_resources" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/pref_category_text_recognition">
         <SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
Close #340 

The following issues should also be fixed by turning on `Keep screenshot resources`:
Close #335 
Close #267 
Close #194 

## Previews

| Before | After |
|--------|--------|
| <video width='300px' src='https://github.com/firemaples/EverTranslator/assets/5812567/c0323877-d92c-40ba-b85c-c5cffdf247ca' /> | <video width='300px' src='https://github.com/firemaples/EverTranslator/assets/5812567/cb8f28ef-838d-4547-871d-a0fdc5e47a01' /> |

| Option for keeping screenshot resources |
|--------|
|<img width='300px' src='https://github.com/firemaples/EverTranslator/assets/5812567/616a0d44-a459-403b-96ef-049bbbc1e92f' />| 