### PR TITLE
Add option for limit the max width of result panel

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/data/repo/SettingRepository.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/data/repo/SettingRepository.kt
@@ -9,4 +9,7 @@ class SettingRepository @Inject constructor() {
 
     fun hideOCRAreaAfterTranslated(): Boolean =
         SettingManager.hideRecognizedResultAfterTranslated
+
+    fun limitResultViewMaxWidth(): Boolean =
+        SettingManager.limitResultViewMaxWidth
 }

--- a/main/src/main/java/tw/firemaples/onscreenocr/data/usecase/GetLimitResultViewMaxWidthUseCase.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/data/usecase/GetLimitResultViewMaxWidthUseCase.kt
@@ -1,0 +1,10 @@
+package tw.firemaples.onscreenocr.data.usecase
+
+import tw.firemaples.onscreenocr.data.repo.SettingRepository
+import javax.inject.Inject
+
+class GetLimitResultViewMaxWidthUseCase @Inject constructor(
+    private val settingRepository: SettingRepository,
+) {
+    operator fun invoke(): Boolean = settingRepository.limitResultViewMaxWidth()
+}

--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewContent.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -97,6 +98,11 @@ fun ResultViewContent(
         ResultPanel(
             modifier = Modifier
                 .padding(16.dp)
+                .run {
+                    if (state.limitMaxWidth)
+                        widthIn(max = 300.dp)
+                    else this
+                }
                 .calculateOffset(
                     highlightUnion = state.highlightUnion,
                     offset = targetOffset,
@@ -462,10 +468,11 @@ private fun ResultViewContentPreview() {
     val state = ResultViewState(
         highlightArea = listOf(areaRect),
         highlightUnion = areaRect,
+        limitMaxWidth = true,
         textSearchEnabled = true,
         ocrState = OCRState(
-            showProcessing = true,
-            ocrText = "Test OCR text",
+            showProcessing = false,
+            ocrText = "Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text Test OCR text ",
         ),
         translationState = TranslationState(
             showTranslationArea = true,

--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewModel.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import tw.firemaples.onscreenocr.R
 import tw.firemaples.onscreenocr.data.usecase.GetCurrentTranslationLangUseCase
 import tw.firemaples.onscreenocr.data.usecase.GetHidingOCRAreaAfterTranslatedUseCase
+import tw.firemaples.onscreenocr.data.usecase.GetLimitResultViewMaxWidthUseCase
 import tw.firemaples.onscreenocr.data.usecase.GetResultViewFontSizeUseCase
 import tw.firemaples.onscreenocr.data.usecase.GetShowTextSelectorOnResultViewUseCase
 import tw.firemaples.onscreenocr.data.usecase.SetShowTextSelectorOnResultViewUseCase
@@ -50,6 +51,7 @@ interface ResultViewModel {
 }
 
 data class ResultViewState(
+    val limitMaxWidth: Boolean = true,
     val textSearchEnabled: Boolean = false,
     val fontSize: Float = Constants.DEFAULT_RESULT_WINDOW_FONT_SIZE,
     val highlightArea: List<Rect> = listOf(),
@@ -97,6 +99,7 @@ class ResultViewModelImpl @Inject constructor(
     getShowTextSelectorOnResultViewUseCase: GetShowTextSelectorOnResultViewUseCase,
     private val setShowTextSelectorOnResultViewUseCase: SetShowTextSelectorOnResultViewUseCase,
     getResultViewFontSizeUseCase: GetResultViewFontSizeUseCase,
+    private val getLimitResultViewMaxWidthUseCase: GetLimitResultViewMaxWidthUseCase,
     private val getCurrentTranslationLangUseCase: GetCurrentTranslationLangUseCase,
     private val getHidingOCRAreaAfterTranslatedUseCase: GetHidingOCRAreaAfterTranslatedUseCase,
 ) : ResultViewModel {
@@ -142,6 +145,12 @@ class ResultViewModelImpl @Inject constructor(
             this@ResultViewModelImpl.parentRect = navState.parentRect
             this@ResultViewModelImpl.selectedRect = navState.selectedRect
             this@ResultViewModelImpl.croppedBitmap = navState.bitmap
+        }
+
+        state.update {
+            it.copy(
+                limitMaxWidth = getLimitResultViewMaxWidthUseCase.invoke(),
+            )
         }
 
         when (navState) {
@@ -208,7 +217,8 @@ class ResultViewModelImpl @Inject constructor(
                             val providerName = context.getString(providerType.nameRes)
                             "${context.getString(R.string.text_translated_by)} $providerName"
                         } else null
-                        val showRecognitionArea = getHidingOCRAreaAfterTranslatedUseCase.invoke().not()
+                        val showRecognitionArea =
+                            getHidingOCRAreaAfterTranslatedUseCase.invoke().not()
 
                         state.update {
                             it.copy(

--- a/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingManager.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/pages/setting/SettingManager.kt
@@ -33,6 +33,7 @@ object SettingManager {
     private const val PREF_AUTO_COPY_OCR_RESULT = "pref_auto_copy_ocr_result"
     private const val PREF_HIDE_RECOGNIZED_RESULT_AFTER_TRANSLATED =
         "pref_hide_recognized_result_after_translated"
+    private const val PREF_LIMIT_RESULT_VIEW_MAX_WIDTH = "pref_limit_result_view_max_width"
 
     private const val PREF_SAVE_LAST_SELECTION_AREA = "pref_save_last_selection_area"
     private const val PREF_EXIT_APP_WHILE_SPEN_INSERTED = "pref_exit_app_while_spen_inserted"
@@ -107,6 +108,9 @@ object SettingManager {
 
     val hideRecognizedResultAfterTranslated: Boolean
         get() = preferences.getBoolean(PREF_HIDE_RECOGNIZED_RESULT_AFTER_TRANSLATED, false)
+
+    val limitResultViewMaxWidth: Boolean
+        get() = preferences.getBoolean(PREF_LIMIT_RESULT_VIEW_MAX_WIDTH, true)
 
     val saveLastSelectionArea: Boolean
         get() = preferences.getBoolean(PREF_SAVE_LAST_SELECTION_AREA, true)

--- a/main/src/main/res/values-zh-rCN/strings.xml
+++ b/main/src/main/res/values-zh-rCN/strings.xml
@@ -114,4 +114,7 @@
     <string name="pref_summary_on_keep_media_projection_resources">维持相关资源直到重启程式</string>
     <string name="pref_summary_off_keep_media_projection_resources">每次使用后释放相关资源</string>
     <string name="pref_screenshot">萤幕截图</string>
+    <string name="pref_limit_result_view_max_width">限制最大宽度</string>
+    <string name="pref_summary_on_limit_result_view_max_width">限制最大宽度至 300dp</string>
+    <string name="pref_summary_off_limit_result_view_max_width">依内容自动调整宽度</string>
 </resources>

--- a/main/src/main/res/values-zh-rTW/strings.xml
+++ b/main/src/main/res/values-zh-rTW/strings.xml
@@ -114,4 +114,7 @@
     <string name="pref_summary_on_keep_media_projection_resources">維持相關資源直到重啟程式</string>
     <string name="pref_summary_off_keep_media_projection_resources">每次使用後釋放相關資源</string>
     <string name="pref_screenshot">螢幕截圖</string>
+    <string name="pref_limit_result_view_max_width">限制最大寬度</string>
+    <string name="pref_summary_on_limit_result_view_max_width">限制最大寬度至 300dp</string>
+    <string name="pref_summary_off_limit_result_view_max_width">不限制寬度</string>
 </resources>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -51,6 +51,9 @@
     <string name="pref_summary_on_keep_media_projection_resources">Keep the resources until restart</string>
     <string name="pref_summary_off_keep_media_projection_resources">Release the resources after used</string>
     <string name="pref_title_keep_media_projection_resources">Keep MediaProjection resources</string>
+    <string name="pref_limit_result_view_max_width">Limit the max width</string>
+    <string name="pref_summary_on_limit_result_view_max_width">Limit the max width to 300dp</string>
+    <string name="pref_summary_off_limit_result_view_max_width">Dynamic width based on the content</string>
 
     <string name="menu_setting">Setting</string>
     <string name="menu_privacy_policy">Privacy Policy</string>

--- a/main/src/main/res/xml/perference.xml
+++ b/main/src/main/res/xml/perference.xml
@@ -96,6 +96,12 @@
             android:defaultValue="false"
             android:key="pref_hide_recognized_result_after_translated"
             android:title="@string/pref_hide_recognized_result_after_translated" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="pref_limit_result_view_max_width"
+            android:summaryOff="@string/pref_summary_off_limit_result_view_max_width"
+            android:summaryOn="@string/pref_summary_on_limit_result_view_max_width"
+            android:title="@string/pref_limit_result_view_max_width" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_other_settings">


### PR DESCRIPTION
Add an option for limiting the max width of the result panel, and the default is on.

| The option |
|--------|
| <img width='300' src='https://github.com/firemaples/EverTranslator/assets/5812567/cc8f9e69-440c-460e-9546-10e6c75031a0' /> |

| Limit max width | Unlimit |
|--------|--------|
| <img width='300' src='https://github.com/firemaples/EverTranslator/assets/5812567/72c885c7-f915-49b5-ae70-c13c1b9d495d' /> | <img width='300' src='https://github.com/firemaples/EverTranslator/assets/5812567/29021fab-92d1-4497-97de-93f66f478bbd' /> | 

Close #433 