### PR TITLE
Make the translator icon smaller

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewContent.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -446,7 +447,9 @@ private fun ColumnScope.TranslationProviderBar(
 
     if (translationProviderIcon != null) {
         Image(
-            modifier = Modifier.align(Alignment.End),
+            modifier = Modifier
+                .align(Alignment.End)
+                .height(16.dp),
             painter = painterResource(id = translationProviderIcon),
             contentDescription = "",
         )


### PR DESCRIPTION
Make the translator icon smaller as the 3.x.x version

| Before | After |
|--------|--------|
| <img width="308" alt="image" src="https://github.com/firemaples/EverTranslator/assets/5812567/f795826d-d1a9-4f51-ac74-443039aea130"> | <img width="311" alt="image" src="https://github.com/firemaples/EverTranslator/assets/5812567/a08825f7-a3b9-4bb4-8fc6-cd1f276b377e"> | 