### PR TITLE
Remove ripple effect on result background

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/base/ComposeUtils.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/base/ComposeUtils.kt
@@ -1,7 +1,10 @@
 package tw.firemaples.onscreenocr.floatings.compose.base
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.Dp
@@ -30,3 +33,14 @@ fun Dp.dpToPx() = with(LocalDensity.current) { this@dpToPx.toPx() }
 
 @Composable
 fun Int.pxToDp() = with(LocalDensity.current) { this@pxToDp.toDp() }
+
+fun Modifier.clickableWithoutRipple(
+    interactionSource: MutableInteractionSource,
+    onClick: () -> Unit
+) = then(
+    Modifier.clickable(
+        interactionSource = interactionSource,
+        indication = null,
+        onClick = { onClick() }
+    )
+)

--- a/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewContent.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/floatings/compose/resultview/ResultViewContent.kt
@@ -5,6 +5,7 @@ import android.graphics.Rect
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -51,6 +52,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import tw.firemaples.onscreenocr.R
+import tw.firemaples.onscreenocr.floatings.compose.base.clickableWithoutRipple
 import tw.firemaples.onscreenocr.floatings.compose.base.dpToPx
 import tw.firemaples.onscreenocr.floatings.compose.base.pxToDp
 import tw.firemaples.onscreenocr.floatings.compose.wigets.WordSelectionText
@@ -64,6 +66,7 @@ fun ResultViewContent(
     requestRootLocationOnScreen: () -> Rect,
 ) {
     val state by viewModel.state.collectAsState()
+    val emptyInteractionSource = remember { MutableInteractionSource() }
 
     LaunchedEffect(Unit) {
         val rootLocation = requestRootLocationOnScreen.invoke()
@@ -77,7 +80,10 @@ fun ResultViewContent(
         modifier = Modifier
             .fillMaxSize()
             .background(colorResource(id = R.color.dialogOutside))
-            .clickable(onClick = viewModel::onDialogOutsideClicked),
+            .clickableWithoutRipple(
+                interactionSource = emptyInteractionSource,
+                onClick = viewModel::onDialogOutsideClicked,
+            ),
     ) {
         state.highlightArea.forEach {
             TextHighlightBox(


### PR DESCRIPTION
The crash issue https://github.com/firemaples/EverTranslator/issues/434 is because of the ripple effect is still running after the view is destroyed.
So try to remove the ripple effect from the background.

## Preview
| Before | After |
|--------|--------|
| <video width='300' src='https://github.com/firemaples/EverTranslator/assets/5812567/329b94fd-f0d6-4edc-844a-0da7583a6331' /> | <video width='300' src='https://github.com/firemaples/EverTranslator/assets/5812567/72de282e-e300-4b30-821c-a0a908e1d66b' /> | 