### PR TITLE
Remove usage of `removeLast()`

### DIFF
--- a/main/src/main/java/tw/firemaples/onscreenocr/utils/WordBoundary.kt
+++ b/main/src/main/java/tw/firemaples/onscreenocr/utils/WordBoundary.kt
@@ -16,14 +16,14 @@ object WordBoundary {
                 // Skip punctuations and blanks
             } else {
                 if (boundaries.size >= 2 && boundaries.last().word.isDash()) {
-                    val sb = StringBuilder(boundaries.removeLast().word)
-                    val lastWord = boundaries.removeLast()
+                    val sb = StringBuilder(boundaries.removeAt(boundaries.lastIndex).word)
+                    val lastWord = boundaries.removeAt(boundaries.lastIndex)
                     sb.insert(0, lastWord.word)
                     sb.append(word)
                     boundaries.add(Boundary(sb.toString(), lastWord.start, end))
                 } else {
                     if (boundaries.isNotEmpty() && boundaries.last().word.isDash()) {
-                        boundaries.removeLast()
+                        boundaries.removeAt(boundaries.lastIndex)
                     }
                     if (word.isDash() && previousWord?.isBlank() == true) {
                         // Skip dash following blank pattern. " -"


### PR DESCRIPTION
## Description

Kotlin incompatibilities will cause crashes
Your app uses Kotlin's removeFirst() and removeLast() extension functions, which conflict with Java functions in Android 15. This will cause apps to crash on devices on Android 14 or earlier. Your app uses these functions in the following places:
C2.g.c
C2.g.k
To avoid crashes, replace all Kotlin removeFirst() and removeLast() function calls with removeAt(0) and removeAt(list.lastIndex).

Technical quality
Release name: 127 (4.0.9)

Learn more: https://developer.android.com/about/versions/15/behavior-changes-15#kotlin-remove-first

<img width="1417" alt="image" src="https://github.com/user-attachments/assets/c93f2825-e46f-4945-bdb5-8eb76c18c6d8" />
